### PR TITLE
Dev

### DIFF
--- a/unraid_restic_setup.sh
+++ b/unraid_restic_setup.sh
@@ -20,19 +20,19 @@ echo_error() {
 echo_info "Welcome to the Restic Installation Script for Unraid!"
 echo_info "This script will install Restic and ensure it remains available after a reboot."
 
-echo "Where would you like to store the Restic binary? [Default: /boot/config/plugins/restic/bin/]"
+echo "Where would you like to store the Restic binary? [Default: /boot/config/plugins/restic/bin]"
 read -r PERSISTENT_DIR
-PERSISTENT_DIR=${PERSISTENT_DIR:-/boot/config/plugins/restic/bin/}
+PERSISTENT_DIR=${PERSISTENT_DIR:-/boot/config/plugins/restic/bin}
 
-echo "The default installation directory is /usr/local/bin/. Do you really want to change it? Proceed with caution! (y/N)"
+echo "The default installation directory is /usr/local/bin/restic. Do you really want to change it? Proceed with caution! (y/N)"
 read -r confirm
 if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
-    INSTALL_PATH="/usr/local/bin/"
+    INSTALL_PATH="/usr/local/bin/restic"
 else
     echo "Please enter the desired installation directory:"
     read -r INSTALL_PATH
 fi
-INSTALL_PATH=${INSTALL_PATH:-/usr/local/bin/}
+INSTALL_PATH=${INSTALL_PATH:-/usr/local/bin/restic}
 
 # Ensure the persistent directory exists
 echo_info "Creating persistent directory: $PERSISTENT_DIR"


### PR DESCRIPTION
This pull request introduces a new script for installing Restic on Unraid, ensuring it persists after a reboot. The script includes functions for user-friendly messaging, prompts for user input on installation paths, and handles downloading and setting up Restic.

Key changes:

* Added a new script `unraid_restic_setup.sh` for interactive installation and auto-persistence of Restic on Unraid.
* Implemented user-friendly message functions (`echo_info`, `echo_success`, `echo_warning`, `echo_error`).
* Introduced prompts for user input on where to store the Restic binary and the installation directory.
* Added logic to fetch the latest Restic version dynamically and download it based on system architecture.
* Ensured Restic persistence after reboot by modifying the `/boot/config/go` file.